### PR TITLE
Increases selector precision to prevent properties being set in error

### DIFF
--- a/src/assets/scss/base/ys-base.scss
+++ b/src/assets/scss/base/ys-base.scss
@@ -2,9 +2,9 @@
 @import '../settings/ys-settings';
 @import '../tools/ys-mixins';
 
-[class*='ys'],
-[class*='ys']::before,
-[class*='ys']::after {
+[class^='ys-'],
+[class^='ys-']::before,
+[class^='ys-']::after {
   box-sizing: border-box;
   font-family: $ys-basefont-stack;
 }

--- a/src/assets/scss/elements/ys-rich-text.scss
+++ b/src/assets/scss/elements/ys-rich-text.scss
@@ -101,6 +101,10 @@
 
   &--light {
     color: $ys-color-grey-98;
+
+    & > *:not([class]) {
+      color: inherit;
+    }
   }
 
   // specific margins


### PR DESCRIPTION
For ys-base:
`[class]*='ys'` would also apply if somebody had a class containing the letters "ys", ie ".s**ys**tem".
`[class]^='ys-` will only apply if an elements classname _begins_ with "ys-" (all our elements).

For ys-rich-text:
This ensures that the font is set in the right color, even if somebody implement our classes and have a color set on "h2" (ie) globally.