### PR TITLE
Left aligned icon in button

### DIFF
--- a/src/assets/scss/elements/ys-button.scss
+++ b/src/assets/scss/elements/ys-button.scss
@@ -140,11 +140,8 @@ html:not(#ys-specificity) .ys-button {
   // Button with icon
   &--icon {
 
-    .ys-button__icon:first-child {
-      margin-right: rem(16);
-    }
-
-    .ys-button__icon:last-child {
+    .ys-button__text + .ys-button__icon,
+    .ys-button__icon + .ys-button__text {
       margin-left: rem(16);
     }
   }

--- a/src/assets/scss/elements/ys-button.scss
+++ b/src/assets/scss/elements/ys-button.scss
@@ -140,8 +140,11 @@ html:not(#ys-specificity) .ys-button {
   // Button with icon
   &--icon {
 
-    .ys-button__text + .ys-button__icon,
-    .ys-button__text + .ys__button__text {
+    .ys-button__icon:first-child {
+      margin-right: rem(16);
+    }
+
+    .ys-button__icon:last-child {
       margin-left: rem(16);
     }
   }

--- a/src/docs/01-Components/05-Form Elements/08-buttons.md
+++ b/src/docs/01-Components/05-Form Elements/08-buttons.md
@@ -84,6 +84,8 @@ All of the above can be include an icon, ie. the *default* button:
 {{render '@button--with-icon'}}
 ```
 
+In some cases it makes sense to place the icon before the text (e.g. a back button) which is also supported.
+
 ## Icon only button
 All button colorways can be displayed with an icon only, ie. the *default* button:
 <div class="element-preview">


### PR DESCRIPTION
A simple fix to https://github.com/youseedk/dna/issues/155 allowing icons to be placed before the button text.

I've removed the `.ys__button__text` selector which wasn't being used anywhere.