### PR TITLE
decreases specificity on grid

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,12 +101,12 @@ gulp.task('css', () => {
     }).on('error', plugins.sass.logError))
     .pipe(plugins.postcss(processors))
     // rename bootstrap classes
-    .pipe(plugins.replace('.container','html:not(#ys-specificity) .ys-container'))
-    .pipe(plugins.replace('.row','html:not(#ys-specificity) .ys-row'))
-    .pipe(plugins.replace('.col','html:not(#ys-specificity) .ys-col'))
-    .pipe(plugins.replace('.order-','html:not(#ys-specificity) .ys-order-'))
-    .pipe(plugins.replace('.offset-','html:not(#ys-specificity) .ys-offset-'))
-    .pipe(plugins.replace('.no-gutters','html:not(#ys-specificity) .ys-no-gutters'))
+    .pipe(plugins.replace('.container','.ys-container'))
+    .pipe(plugins.replace('.row','.ys-row'))
+    .pipe(plugins.replace('.col','.ys-col'))
+    .pipe(plugins.replace('.order-','.ys-order-'))
+    .pipe(plugins.replace('.offset-','.ys-offset-'))
+    .pipe(plugins.replace('.no-gutters','.ys-no-gutters'))
     .pipe(gulp.dest(paths.destination.css))
     .pipe(plugins.postcss(minifying))
     .pipe(plugins.rename({


### PR DESCRIPTION
The bootstrap file is not structured in a way, where we can avoid the specificity-hack being doubled or even tripled, so I suggest we remove it from the grid (which we have very little control over already).

This should pose no issues as far as I can see.