### PR TITLE
Add missing `viewBox` attribute to SVG icons

### DIFF
--- a/src/assets/svg/ui-icons/check-mark.svg
+++ b/src/assets/svg/ui-icons/check-mark.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="10"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1.5 5.124L5.01 8.75l5.49-7.5"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10">
+  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1.5 5.124L5.01 8.75l5.49-7.5"/>
+</svg>

--- a/src/assets/svg/ui-icons/exclamation-mark.svg
+++ b/src/assets/svg/ui-icons/exclamation-mark.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="2" height="12"><g fill="none" fill-rule="evenodd"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1v6"/><path fill="currentColor" d="M2 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 12">
+  <g fill="none" fill-rule="evenodd">
+    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1v6"/>
+    <path fill="currentColor" d="M2 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+  </g>
+</svg>

--- a/src/assets/svg/ui-icons/information.svg
+++ b/src/assets/svg/ui-icons/information.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="2" height="12"><g fill="none" fill-rule="evenodd"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5v6"/><path fill="currentColor" d="M2 1a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 12">
+  <g fill="none" fill-rule="evenodd">
+    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5v6"/>
+    <path fill="currentColor" d="M2 1a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+  </g>
+</svg>


### PR DESCRIPTION
Replace `width` and `height` attributes with `viewBox` in recently changed icons.

Fixes https://github.com/youseedk/dna/issues/166.