### PR TITLE
Reset margin on Shortcut icon container

### DIFF
--- a/src/assets/scss/elements/ys-shortcut.scss
+++ b/src/assets/scss/elements/ys-shortcut.scss
@@ -15,6 +15,7 @@ html:not(#ys-specificity) .ys-shortcut {
     width: rem(72);
     height: rem(72);
     position: relative;
+    margin: 0;
 
     &::after {
       content: '';


### PR DESCRIPTION
`.ys-shortcut__icon-container` is meant to be used with the `<figure>` element which has a default margin (at least outside the Fractal environment). This is a simple reset of that margin.