### PR TITLE
Inherit link color

### DIFF
--- a/src/assets/scss/elements/ys-link.scss
+++ b/src/assets/scss/elements/ys-link.scss
@@ -8,14 +8,7 @@ html:not(#ys-specificity) .ys-link {
   text-decoration: underline;
 
   &:hover {
-    color: $ys-color-grey-28;
-  }
-
-  &--dark {
-
-    &:hover {
-      color: $ys-color-white;
-    }
+    color: inherit;
   }
 
   /* stylelint-disable color-no-hex */


### PR DESCRIPTION
A suggestion to simple inherit the link color because:
- It's easier to use for the developers.
- It works with all text colors. Right now only `#484848` and `#ffffff` are supported.
- We don't have to update [the documentation](https://dna.yousee.dk/docs/components/text/link) that's currently missing a `ys-link--dark` class ;)
- Less code to maintain.