### PR TITLE
Move color from form element label container to label mixin

### DIFF
--- a/src/assets/scss/elements/ys-input-field.scss
+++ b/src/assets/scss/elements/ys-input-field.scss
@@ -4,7 +4,6 @@
 @import '../tools/ys-functions';
 
 .ys-input-field {
-  color: $ys-color-grey-46;
 
   &__label {
     font-size: rem(12);

--- a/src/assets/scss/elements/ys-select.scss
+++ b/src/assets/scss/elements/ys-select.scss
@@ -4,7 +4,6 @@
 @import '../tools/ys-functions';
 
 .ys-select {
-  color: $ys-color-grey-46;
 
   &__label {
     font-size: rem(12);

--- a/src/assets/scss/elements/ys-slider.scss
+++ b/src/assets/scss/elements/ys-slider.scss
@@ -121,6 +121,7 @@
   &__minmax-label {
     font-weight: 400;
     line-height: 1.5;
+    color: $ys-color-grey-28;
   }
 
   &__data-set {
@@ -136,6 +137,7 @@
     text-align: center;
     font-size: rem(12);
     font-weight: 400;
+    color: $ys-color-grey-28;
 
     // hide visual labels on small screens
     @media screen and (max-width: $ys-breakpoint-sm) {

--- a/src/assets/scss/elements/ys-textarea.scss
+++ b/src/assets/scss/elements/ys-textarea.scss
@@ -6,7 +6,6 @@
 .ys-textarea {
   position: relative;
   min-height: rem(80);
-  color: $ys-color-grey-46;
 
   &__label {
     font-size: rem(12);

--- a/src/assets/scss/tools/_ys-mixins.scss
+++ b/src/assets/scss/tools/_ys-mixins.scss
@@ -12,9 +12,10 @@
   transition: box-shadow .2s ease-out;
 }
 
-// Label Text for input field, select and textarea
+// Label Text for input field, select, textarea and slider
 @mixin labelText() {
   display: block;
+  color: $ys-color-grey-46;
   margin-bottom: rem(8);
   font-weight: 600;
   text-transform: uppercase;


### PR DESCRIPTION
This PR moves the general `color` property to the label mixin used by several form elements. This has multiple advantages:

- Prevents the label in the slider component from inheriting color.
- Reduces the risk of overrides of label color as it's now specifically added to the label text class.
- Moves multiple declarations into the shared mixin.

`*__guidance` elements have a color as well, so unless I'm missing something this shouldn't affect anything else than the labels.

Bonus: Added a tiny fix for slider labels that would otherwise also inherit color.