### PR TITLE
Fixed unintentional red border on required input field in firefox

### DIFF
--- a/src/assets/scss/elements/ys-input-field.scss
+++ b/src/assets/scss/elements/ys-input-field.scss
@@ -102,6 +102,10 @@
       @include customOutline;
     }
 
+    &:required {
+      box-shadow: none;
+    }
+
     &[readonly]:focus {
       font-weight: 600;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9862931/64015117-19958000-cb24-11e9-8619-af7252796a18.png)

set box shadow to none, to remove red outline