### PR TITLE
Fix button `block` modifier and add it to the docs

### DIFF
--- a/src/assets/scss/elements/ys-button.scss
+++ b/src/assets/scss/elements/ys-button.scss
@@ -117,15 +117,8 @@
     }
   }
 
-  // block takes up 100% width of it's container
   &--block {
     min-width: 100%;
-
-    &::before,
-    &::after {
-      content: '';
-      flex: 0 0 rem(48);
-    }
   }
 
   // Button with icon

--- a/src/docs/01-Components/05-Form Elements/08-buttons.md
+++ b/src/docs/01-Components/05-Form Elements/08-buttons.md
@@ -105,6 +105,15 @@ All button colorways can be displayed with an icon only, ie. the *default* butto
 ```
 Important: Never leave out the `<span class="ys-button__text">` element, as this is included for accessibility purposes.
 
+## Full width button
+<div class="element-preview">
+  <div class="element-preview__inner">{{render '@button--block'}}</div>
+</div>
+
+```html
+{{render '@button--block'}}
+```
+
 
 # HTML Guidelines
  - Only `<a>` and `<button>` elements are allowed to use the `.button` class


### PR DESCRIPTION
This PR fixes two things:

**1. Off-center button text in IE11**
I'm honestly not sure why we even have these pseudo-elements (git blame reveals nothing) in the first place but they're causing the text to be misaligned in IE11, so I suggest we just get rid of them.
![15 gb](https://user-images.githubusercontent.com/3898396/68596157-119a7a80-049b-11ea-8c07-e15c3ee8b978.PNG)

**2. Missing `--block` modifier in the documentation**
There was no mention of the `--block` modifier in the docs, so I added a simple example.