### PR TITLE
Flow Steps: Vertical variant

### DIFF
--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -4,7 +4,13 @@
 @import '../tools/ys-functions';
 
 .ys-flow-steps {
+  $variant-vertical-ref: 0;
+  $bullet-size-px: 34;
   color: $ys-color-grey-28;
+
+  &--vertical {
+    $variant-vertical-ref: &;
+  }
 
   &__list {
     margin: 0;
@@ -14,18 +20,31 @@
     flex-flow: row;
     counter-reset: progress-bullet;
     text-align: center;
+
+    #{$variant-vertical-ref} & {
+      flex-direction: column;
+      text-align: left;
+    }
   }
 
   &__item {
     position: relative;
     flex: 1 0 10px;
-    padding-top: rem(34);
+    padding-top: rem($bullet-size-px);
     font-size: rem(14);
     counter-increment: progress-bullet;
     list-style-type: none;
 
     @media screen and (min-width: $ys-breakpoint-md) {
       padding-top: rem(42);
+    }
+
+    #{$variant-vertical-ref} & {
+      display: flex;
+      padding-top: 0;
+      padding-left: rem(46);
+      align-items: center;
+      min-height: rem(50);
     }
 
     // ::before is the line in the bg
@@ -38,6 +57,13 @@
       height: rem(2);
       width: 100%;
       background-color: $ys-color-digital-moss;
+
+      #{$variant-vertical-ref} & {
+        height: 100%;
+        width: rem(2);
+        top: -50%;
+        left: rem($bullet-size-px / 2 - 1);
+      }
     }
 
     &:first-child::before {
@@ -46,13 +72,14 @@
 
     // ::after is the actual "bullets"
     &::after {
+      $bullet-center-point: calc(50% - #{rem($bullet-size-px / 2)});
       content: '';
       position: absolute;
       z-index: 1;
       top: 0;
-      left: calc(50% - #{rem(17)});
-      width: rem(34);
-      height: rem(34);
+      left: $bullet-center-point;
+      width: rem($bullet-size-px);
+      height: rem($bullet-size-px);
       border-radius: 50%;
       background: $ys-color-digital-moss url('data:image/svg+xml,%3Csvg viewBox%3d%22-1 -2 16 16%22 xmlns%3d%22http://www.w3.org/2000/svg%22%3E%3Cpath fill%3d%22none%22 fill-rule%3d%22evenodd%22 stroke%3d%22%23fff%22 stroke-linecap%3d%22round%22 stroke-linejoin%3d%22round%22 stroke-width%3d%222%22 d%3d%22M1 6.16534L5.68013 11 13 1%22/%3E%3C/svg%3E') no-repeat center;
       background-size: 14px 14px;
@@ -61,6 +88,11 @@
       font-size: rem(16);
       line-height: rem(30);
       font-weight: 600;
+
+      #{$variant-vertical-ref} & {
+        left: 0;
+        top: $bullet-center-point;
+      }
     }
 
     &--active {
@@ -93,7 +125,9 @@
   &__label {
     font-weight: 600;
     line-height: rem(20);
+  }
 
+  &:not(#{$variant-vertical-ref}) &__label {
     @media screen and (max-width: $ys-breakpoint-md) {
       display: none;
     }

--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -4,13 +4,8 @@
 @import '../tools/ys-functions';
 
 .ys-flow-steps {
-  $variant-vertical-ref: &;
   $bullet-size-px: 34;
   color: $ys-color-grey-28;
-
-  &--vertical {
-    $variant-vertical-ref: &;
-  }
 
   &__list {
     margin: 0;
@@ -20,7 +15,7 @@
     counter-reset: progress-bullet;
     text-align: center;
 
-    #{$variant-vertical-ref} & {
+    .ys-flow-steps--vertical & {
       flex-direction: column;
       text-align: left;
     }
@@ -38,7 +33,7 @@
       padding-top: rem(42);
     }
 
-    #{$variant-vertical-ref} & {
+    .ys-flow-steps--vertical & {
       display: flex;
       padding-top: 0;
       padding-left: rem(48);
@@ -57,7 +52,7 @@
       width: 100%;
       background-color: $ys-color-digital-moss;
 
-      #{$variant-vertical-ref} & {
+      .ys-flow-steps--vertical & {
         height: 100%;
         width: rem(2);
         top: -50%;
@@ -88,15 +83,13 @@
       line-height: rem(30);
       font-weight: 600;
 
-      #{$variant-vertical-ref} & {
+      .ys-flow-steps--vertical & {
         left: 0;
         top: $bullet-center-point;
       }
     }
 
     &--active {
-      $active-item-ref: &;
-
       // Change color of line
       & ~ .ys-flow-steps__item::before {
         background-color: $ys-color-grey-28;
@@ -112,7 +105,7 @@
       }
 
       // "Bullets" after the active "bullet"
-      & ~ .ys-flow-steps__item:not(#{$active-item-ref})::after {
+      & ~ .ys-flow-steps__item:not(.ys-flow-steps__item--active)::after {
         content: counter(progress-bullet);
         background-color: $ys-color-white;
         background-image: none;
@@ -127,7 +120,7 @@
     line-height: rem(20);
   }
 
-  &:not(#{$variant-vertical-ref}) &__label {
+  &:not(.ys-flow-steps--vertical) &__label {
     @media screen and (max-width: $ys-breakpoint-md) {
       display: none;
     }

--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -17,7 +17,6 @@
     padding: 0;
     list-style: none;
     display: flex;
-    flex-flow: row;
     counter-reset: progress-bullet;
     text-align: center;
 
@@ -29,7 +28,7 @@
 
   &__item {
     position: relative;
-    flex: 1 0 10px;
+    flex: 1 0;
     padding-top: rem($bullet-size-px);
     font-size: rem(14);
     counter-increment: progress-bullet;

--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -4,7 +4,7 @@
 @import '../tools/ys-functions';
 
 .ys-flow-steps {
-  $variant-vertical-ref: 0;
+  $variant-vertical-ref: &;
   $bullet-size-px: 34;
   color: $ys-color-grey-28;
 
@@ -41,9 +41,9 @@
     #{$variant-vertical-ref} & {
       display: flex;
       padding-top: 0;
-      padding-left: rem(46);
+      padding-left: rem(48);
       align-items: center;
-      min-height: rem(50);
+      min-height: rem(48);
     }
 
     // ::before is the line in the bg

--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -16,7 +16,7 @@
     text-align: center;
 
     .ys-flow-steps--vertical & {
-      flex-direction: column;
+      display: initial;
       text-align: left;
     }
   }
@@ -38,7 +38,7 @@
       padding-top: 0;
       padding-left: rem(48);
       align-items: center;
-      min-height: rem(48);
+      height: rem(64);
     }
 
     // ::before is the line in the bg

--- a/src/assets/scss/elements/ys-flow-steps.scss
+++ b/src/assets/scss/elements/ys-flow-steps.scss
@@ -95,6 +95,7 @@
     }
 
     &--active {
+      $active-item-ref: &;
 
       // Change color of line
       & ~ .ys-flow-steps__item::before {
@@ -111,7 +112,7 @@
       }
 
       // "Bullets" after the active "bullet"
-      & ~ .ys-flow-steps__item::after {
+      & ~ .ys-flow-steps__item:not(#{$active-item-ref})::after {
         content: counter(progress-bullet);
         background-color: $ys-color-white;
         background-image: none;

--- a/src/docs/01-Components/06-Feedback/03-flow-steps.md
+++ b/src/docs/01-Components/06-Feedback/03-flow-steps.md
@@ -25,6 +25,15 @@ secondaryKeywords: minvalue maxvalue valuemax valuemin
 {{render '@flow-steps'}}
 ```
 
+## Vertical flow steps
+<div class="element-preview">
+  <div class="element-preview__inner">{{render '@flow-steps--vertical'}}</div>
+</div>
+
+```html
+{{render '@flow-steps--vertical'}}
+```
+
 # HTML Guidelines
 
 # UX and Design Guidelines

--- a/src/elements/02-elements/flow-steps/flow-steps.config.js
+++ b/src/elements/02-elements/flow-steps/flow-steps.config.js
@@ -2,10 +2,18 @@ module.exports = {
   status: "wip",
   preview: "@element-preview",
   label: "Flow Steps",
+  isVertical: false,
   variants: [
     {
       name: "default",
       label: "Flow Steps"
+    },
+    {
+      name: "vertical",
+      label: "Flow Steps Vertical",
+      context: {
+        isVertical: true
+      }
     }
   ],
   "context": {

--- a/src/elements/02-elements/flow-steps/flow-steps.hbs
+++ b/src/elements/02-elements/flow-steps/flow-steps.hbs
@@ -1,4 +1,4 @@
-<div class="ys-flow-steps" role="progressbar" aria-valuenow="3"
+<div class="ys-flow-steps{{#if isVertical}} ys-flow-steps--vertical{{/if}}" role="progressbar" aria-valuenow="3"
     aria-valuemin="0" aria-valuetext="Task description" aria-valuemax="5">
     <ol class="ys-flow-steps__list" aria-hidden="true">
         <li class="ys-flow-steps__item">


### PR DESCRIPTION
This has been bugging me for quite some time - the labels in the flow steps component are hidden below a certain viewport width like so:
<img width="264" alt="Screenshot 2020-07-07 at 21 56 38" src="https://user-images.githubusercontent.com/3898396/86837853-cd01c600-c09f-11ea-833b-0d51664559ab.png">
This renders the component pretty useless for seeing people not relying on the aria attributes. I propose we introduce a vertical variant (I even believe Bo designed something similar):
<img width="122" alt="Screenshot 2020-07-07 at 21 57 08" src="https://user-images.githubusercontent.com/3898396/86838564-a09a7980-c0a0-11ea-9289-c7fb3ce28432.png">
The reasons for introducing a variant instead of just using media queries are two-fold:

1. Avoiding introducinging breaking changes in the existing component
2. Leaving it up to the designer and developer when to use what version

### One caveat
If an item spans more than a couple of lines it will break
<img width="210" alt="Screenshot 2020-07-07 at 21 58 54" src="https://user-images.githubusercontent.com/3898396/86839815-31258980-c0a2-11ea-8762-b7275e1695a6.png">
This is because the connectors are built on the assumption that the distance between each bullet always is the same. Two possible solutions, as I see it: Always set a height on the container and let flexbox distribute the items evenly (easy), or change the connectors so they allow for various heights/widths of each item (a bit more work). That way we would also be able to do things like:
<img width="461" alt="Screenshot 2020-07-07 at 22 51 25" src="https://user-images.githubusercontent.com/3898396/86841619-764abb00-c0a4-11ea-91a5-5bd9b5b9cdf9.png">

**Thoughts?**