### PR TITLE
fix styling for autosuggestions in chromium browsers

### DIFF
--- a/src/assets/scss/elements/ys-input-field.scss
+++ b/src/assets/scss/elements/ys-input-field.scss
@@ -72,6 +72,10 @@
     &::ms-input-placeholder {
       color: $ys-color-grey-64;
     }
+
+    &:-webkit-autofill {
+      -webkit-background-clip: text;
+    }
     // stylelint-enable
 
     &:disabled,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9862931/93064378-bcf5fc00-f677-11ea-8f9e-05bf421aaede.png)

After selecting an option from the chrome autosuggestion dropdown, the styling gets a bit wack.
This PR fixes that.
Since it is a chromium-specific error, I have also applied a chromium-specific fix.