### PR TITLE
Correct engine version notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "ys-bundle.min.css",
   "style": "ys-bundle.min.css",
   "engines": {
-    "node": "^12"
+    "node": ">=12"
   },
   "scripts": {
     "start": "gulp",


### PR DESCRIPTION
As per npm documentation:
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines